### PR TITLE
fix: Duplicate lines handling

### DIFF
--- a/lib/active_admin_file_importer/execution.rb
+++ b/lib/active_admin_file_importer/execution.rb
@@ -30,7 +30,7 @@ module ActiveAdminFileImporter
       @items
         .group_by(&:digest)
         .filter { |_digest, values| values.length > 1 }
-        .flat_map { |_key, values| values }
+        .flat_map { |_key, values| values.sort_by {|v| v.index}[1..] }
         .each(&:repeated!)
         .length
     end


### PR DESCRIPTION
When handling groups of duplicate lines, the least recent one should not be treated as a duplicate (i.e. If lines 1, 5, and 10 have the same values, only the last two should be marked as duplicates).